### PR TITLE
Add dependency setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # SearchPubmedExample
+
+## Setup dependencies
+
+Run the `setup_and_load.py` script to install the required Python packages and
+load the modules used by this repository:
+
+```bash
+python setup_and_load.py
+```

--- a/setup_and_load.py
+++ b/setup_and_load.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+
+PACKAGES = [
+    "pandas",
+    "biopython",
+    "rapidfuzz",
+    "searchpubmed",
+]
+
+def install_packages():
+    for pkg in PACKAGES:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+
+def load_dependencies():
+    import pandas as pd  # noqa: F401
+    from Bio import Entrez  # noqa: F401
+    from searchpubmed.pubmed import (  # noqa: F401
+        get_pmid_from_pubmed,
+        map_pmids_to_pmcids,
+        get_pmc_full_xml,
+        get_pubmed_metadata_pmid,
+    )
+
+
+def main():
+    install_packages()
+    load_dependencies()
+    print("Dependencies installed and loaded.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `setup_and_load.py` for installing dependencies and loading modules
- document how to run the setup script in the README

## Testing
- `python -m py_compile setup_and_load.py`


------
https://chatgpt.com/codex/tasks/task_e_686d17b19ca4832ca4495b28cf9062a9